### PR TITLE
Changed transactions key

### DIFF
--- a/public/javascripts/build/app.js
+++ b/public/javascripts/build/app.js
@@ -23899,7 +23899,7 @@ module.exports = React.createClass({displayName: "exports",
         React.createElement("tbody", null, 
           React.createElement(Transaction_row, {isNew: true, transaction: this.state.newTransaction, owner: this.state.owner, onUpdate: this.onUpdate, key: moment().unix()}), 
           this.state.transactions.map(function (row, index) {
-            return React.createElement(Transaction_row, {transaction: row, owner: _self.state.owner, onUpdate: _self.onUpdate, onCancel: _self.resetTransaction, key: moment().unix()});
+            return React.createElement(Transaction_row, {transaction: row, owner: _self.state.owner, onUpdate: _self.onUpdate, onCancel: _self.resetTransaction, key: index});
           })
         )
       )

--- a/public/javascripts/src/Transactions.jsx
+++ b/public/javascripts/src/Transactions.jsx
@@ -60,7 +60,7 @@ module.exports = React.createClass({
         <tbody>
           <Transaction_row isNew={true} transaction={this.state.newTransaction} owner={this.state.owner} onUpdate={this.onUpdate} key={moment().unix()} />
           {this.state.transactions.map(function (row, index) {
-            return <Transaction_row transaction={row} owner={_self.state.owner} onUpdate={_self.onUpdate} onCancel={_self.resetTransaction} key={moment().unix()} />;
+            return <Transaction_row transaction={row} owner={_self.state.owner} onUpdate={_self.onUpdate} onCancel={_self.resetTransaction} key={index} />;
           })}
         </tbody>
       </table>


### PR DESCRIPTION
In reference to this error:

Warning: flattenChildren(...): Encountered two children with the same key, `.1:$1461383928`. Child keys must be unique; when two children share a key, only the first child will be used.